### PR TITLE
Update dependencies to latest version VS2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-build
+build*
 extern

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Compile options
+IF(MSVC)
+	add_compile_options(/MP)
+ENDIF(MSVC)
+
 # Configure include directories
 include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/test)

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,9 +17,9 @@ class JWTUtilsConan(ConanFile):
 		self.options["openssl"].shared = True
 
 	def requirements(self):
-		self.requires("RapidJSONAdapter/1.1.6@systelab/stable")
-		self.requires("zlib/1.2.13#13c96f538b52e1600c40b88994de240f", override=True)
-		self.requires("openssl/3.0.12#1670458f93ec138c3bb6afc65a1cd667")
+		self.requires("RapidJSONAdapter/1.1.7@systelab/stable")
+		self.requires("zlib/1.3.1@#f52e03ae3d251dec704634230cd806a2", override=True)
+		self.requires("openssl/3.0.14@#a723a7081f2ca0811fafd9a6420252db")
 		self.requires("gtest/1.14.0#4372c5aed2b4018ed9f9da3e218d18b3")
 
 	def build(self):

--- a/vs2022.conanprofile
+++ b/vs2022.conanprofile
@@ -5,8 +5,5 @@ compiler=Visual Studio
 compiler.version=17
 compiler.toolset=v143
 
-RapidJSONAdapter:compiler.version=16
-RapidJSONAdapter:compiler.toolset=v142
-
 [options]
 openssl:shared=true


### PR DESCRIPTION
Updated dependencies to latest versions we have in relation with VS2022
* OpenSSL 3.0.12 -> 3.0.14
* zlib 1.2.13 -> 1.3.1
* RapidJSONAdapter 1.1.6 -> 1.1.7 (VS2022) SNOW-22526